### PR TITLE
style: 💄 Prettier の指摘に従い空っぽの中身のタグを自己完結させた

### DIFF
--- a/public/red_room1.html
+++ b/public/red_room1.html
@@ -1,10 +1,10 @@
 <html>
   <head>
-    <meta http-equiv=Content-Type content="text/html;  charset=SHIFT_JIS">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Type" content="text/html;  charset=SHIFT_JIS" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>red_room1</title>
     <script src="https://unpkg.com/@ruffle-rs/ruffle"></script>
-    <style type = "text/css">
+    <style type="text/css">
       * {
         color: white;
         text-align: center;
@@ -29,7 +29,8 @@
         margin: 0 auto;
       }
 
-      object, embed {
+      object,
+      embed {
         width: 100%;
         height: 100%;
       }
@@ -60,22 +61,31 @@
       }
     </style>
   </head>
-<body>
-  <div class="game-container">
-    <object
-      classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000"
-      codebase="http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=6,0,0,0"
-      width="400" height="300" id="red_room1" align=""
-    >
-      <param name="movie" value="red_room1.swf">
-      <param name="quality" value="high">
-      <param name="bgcolor" value="#000000">
-      <embed
-        src="red_room1.swf" quality="high" bgcolor="#000000"
-        width="400" height="300" name="red_room1" align=""
-        type="application/x-shockwave-flash" pluginspage="http://www.macromedia.com/go/getflashplayer"
-      ></embed>
-    </object>
-  </div>
-</body>
+  <body>
+    <div class="game-container">
+      <object
+        classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000"
+        codebase="http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=6,0,0,0"
+        width="400"
+        height="300"
+        id="red_room1"
+        align=""
+      >
+        <param name="movie" value="red_room1.swf" />
+        <param name="quality" value="high" />
+        <param name="bgcolor" value="#000000" />
+        <embed
+          src="red_room1.swf"
+          quality="high"
+          bgcolor="#000000"
+          width="400"
+          height="300"
+          name="red_room1"
+          align=""
+          type="application/x-shockwave-flash"
+          pluginspage="http://www.macromedia.com/go/getflashplayer"
+        />
+      </object>
+    </div>
+  </body>
 </html>


### PR DESCRIPTION
This pull request makes formatting and consistency improvements to the `public/red_room1.html` file. The changes focus on making the HTML code more standards-compliant and easier to read by adding self-closing tags where appropriate, reformatting attributes, and improving indentation.

### Formatting improvements:

* Updated the `meta` tags to use self-closing syntax for better HTML5 compliance. (`public/red_room1.html`, [public/red_room1.htmlL3-R4](diffhunk://#diff-d8437e92c70efe15da15fe6fb4951db436fb490d4776afd43ffb12d28f35cf36L3-R4))
* Reformatted the `object` and `embed` CSS selectors for consistent indentation and readability. (`public/red_room1.html`, [public/red_room1.htmlL32-R33](diffhunk://#diff-d8437e92c70efe15da15fe6fb4951db436fb490d4776afd43ffb12d28f35cf36L32-R33))
* Adjusted the `object` and `embed` elements to use self-closing syntax for `param` tags and improved attribute alignment for better readability. (`public/red_room1.html`, [public/red_room1.htmlL68-R87](diffhunk://#diff-d8437e92c70efe15da15fe6fb4951db436fb490d4776afd43ffb12d28f35cf36L68-R87))